### PR TITLE
feat: add método europeo copy

### DIFF
--- a/src/components/landing/content-section.tsx
+++ b/src/components/landing/content-section.tsx
@@ -106,14 +106,13 @@ export function ContentSection() {
         {/* Encabezado */}
         <div className="text-center mb-16 lg:mb-20">
           <span className="inline-block bg-golden/20 text-golden px-4 py-2 rounded-full text-xs font-bold tracking-wider mb-4">
-            SISTEMA COMPROBADO
+            TODO LO QUE INCLUYE
           </span>
           <h2 className="font-display text-3xl sm:text-4xl lg:text-5xl font-black text-white mb-5">
-            Domina el <span className="text-golden">Upsell en 4 </span><br />
-            Pasos Clave
+            El Método <span className="text-golden">Europeo</span>
           </h2>
           <p className="text-lg text-white/85 max-w-3xl mx-auto">
-            Método probado que ha aumentado ingresos en un <strong className="text-golden">217%</strong> a emprendedores
+            Aprende cómo montamos tiendas de marca, elegimos productos ganadores y lanzamos anuncios que venden desde cero.
           </p>
         </div>
 
@@ -159,6 +158,7 @@ export function ContentSection() {
 
         {/* CTA con temporizador dinámico */}
         <div className="text-center">
+          <h3 className="text-2xl font-bold text-white mb-4">Panel de compra</h3>
           <div className="inline-block w-full max-w-2xl bg-gradient-to-r from-black via-black to-golden/20 border border-golden/30 rounded-2xl px-6 py-6 sm:px-10 sm:py-8 mb-8 overflow-hidden relative">
             {/* Sello de urgencia */}
             <div className="absolute -top-3 -right-3 bg-red-600 text-white text-xs font-bold px-3 py-1 rounded-full rotate-12 animate-pulse">
@@ -221,6 +221,10 @@ export function ContentSection() {
               <span>Soporte prioritario</span>
             </div>
           </div>
+
+          <p className="mt-8 text-xs text-white/70 max-w-lg mx-auto">
+            AVISO: Limite de personas por semana para no saturar. ¿Por qué? Para dar el mejor servicio.
+          </p>
         </div>
       </div>
     </section>

--- a/src/components/landing/creator-section.tsx
+++ b/src/components/landing/creator-section.tsx
@@ -34,15 +34,15 @@ export function CreatorSection() {
           {/* Contenido - Versión potente */}
           <div className="w-full lg:w-1/2 xl:w-7/12">
             <span className="inline-block bg-golden/10 text-golden px-4 py-2 rounded-full text-xs font-bold tracking-wider mb-5 uppercase">
-              El Mentor que multiplicará tus ingresos
+              Los creadores del Método Europeo
             </span>
             <h2 className="font-display text-3xl sm:text-4xl lg:text-5xl font-black text-gray-900 mb-4">
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-golden to-golden/80">Pascu Moreno </span>
-              Formando emprendedores digitales
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-golden to-golden/80">Pascu</span>, Raúl y Jesús
+              <br />Los únicos europeos en facturar millones en Europa y LATAM
             </h2>
             <div className="prose-xl text-gray-700 mb-8 space-y-4">
               <p>
-                <strong className="text-golden">"Deja de complicarte"</strong> - Aquí está el sistema exacto que usé para generar <strong>$3,700,000+</strong> en ventas y que ahora enseño a mis alumnos.
+                Historia de Pascu: cómo consiguió su primer millón y todo lo que vino después, ahora al alcance de todos con nuestro método.
               </p>
               
               <ul className="space-y-3 pl-5">

--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -28,15 +28,22 @@ export function HeroSection() {
           {/* Content - Mejor jerarquía */}
           <div className="text-center lg:text-left animate-fade-in">
             <h1 className="font-display text-4xl sm:text-5xl lg:text-5xl xl:text-6xl font-black text-foreground mb-4 lg:mb-6 leading-tight">
-              Convierte tu conocimiento en{" "}
+              DESCUBRE CÓMO GANAR 5000 USD EN MENOS DE 30 DÍAS <br />
               <span className="text-transparent bg-gradient-golden bg-clip-text">
-                ingresos recurrentes
+                O TE PAGAMOS 50 USD
               </span>
             </h1>
-            
+
             <p className="text-lg sm:text-xl lg:text-2xl text-muted-foreground mb-6 lg:mb-8 max-w-2xl mx-auto lg:mx-0 leading-relaxed">
-              Domina el sistema <strong className="text-golden">paso a paso</strong> para crear infoproductos escalables y dominar el <u>upsell</u> incluso si no tienes experiencia.
+              El método europeo que nos hace facturar millones en Europa del Este y en Latinoamérica con contra entrega. Te damos el método al completo y sin secretos con todas las herramientas necesarias.
             </p>
+
+            <ul className="text-muted-foreground mb-6 lg:mb-8 space-y-2 max-w-xl mx-auto lg:mx-0 text-base sm:text-lg">
+              <li>✅ Cómo hacer tu tienda profesional de marca</li>
+              <li>✅ 5 productos ganadores</li>
+              <li>✅ Cómo hacer anuncios de marca</li>
+              <li>✅ De 0 a 100 sin experiencia previa</li>
+            </ul>
             
             {/* CTA mejorado */}
             <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start mb-6 lg:mb-8">


### PR DESCRIPTION
## Summary
- add bold promise and bullet list to hero section
- present Método Europeo content with purchase panel and notice
- highlight creators as Pascu, Raúl y Jesús

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; A require() style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6074527e4832a8dae807fa0d9624c