### PR TITLE
Enhance policy pages with logo and shared footer

### DIFF
--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,26 +1,49 @@
+import { Footer } from "@/components/landing/footer";
+
 const PrivacyPolicy = () => (
-  <div className="min-h-screen bg-gradient-to-b from-gray-900 to-gray-950 text-gray-100 py-20 px-4">
-    <div className="container mx-auto max-w-3xl space-y-6">
-      <h1 className="text-4xl font-bold mb-10 text-center">Política de Privacidad</h1>
-      <p>
-        En COINNECTA valoramos tu privacidad. Esta política explica cómo recopilamos,
-        utilizamos y protegemos tu información personal cuando usas nuestro sitio web
-        y servicios.
+  <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-900 to-gray-950 text-gray-100">
+    <div className="flex-grow container mx-auto max-w-3xl px-4 py-20">
+      <div className="flex justify-center mb-10">
+        <img src={"images/logo.png"} alt="COINNECTA" className="w-40 lg:w-52" />
+      </div>
+      <h1 className="text-4xl font-bold text-center mb-8">Política de Privacidad</h1>
+      <p className="mb-4">
+        En COINNECTA nos comprometemos a proteger tu información personal. Esta
+        política describe qué datos recopilamos y cómo los utilizamos cuando accedes
+        a nuestro sitio.
       </p>
-      <p>
-        Solo recopilamos los datos necesarios para brindarte una experiencia segura
-        y personalizada. Nunca compartiremos tu información con terceros sin tu
-        consentimiento, salvo cuando lo exija la ley.
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Información que recopilamos</h2>
+      <p className="mb-4">
+        Recopilamos datos que nos proporcionas directamente, como nombre y correo,
+        además de información de navegación mediante cookies y herramientas
+        analíticas.
       </p>
-      <p>
-        Puedes ejercer tus derechos de acceso, rectificación o eliminación de tus
-        datos personales escribiéndonos a
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Uso de la información</h2>
+      <p className="mb-4">
+        Utilizamos tus datos para brindarte y mejorar nuestros servicios, procesar
+        pagos y enviarte comunicaciones relevantes.
+      </p>
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Cookies</h2>
+      <p className="mb-4">
+        Empleamos cookies para recordar tus preferencias y analizar el uso del
+        sitio. Puedes desactivarlas desde la configuración de tu navegador.
+      </p>
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Tus derechos</h2>
+      <p className="mb-4">
+        Puedes acceder, actualizar o solicitar la eliminación de tus datos
+        personales escribiéndonos a
         <a href="mailto:hola@coinnecta.com" className="text-golden underline ml-1">
           hola@coinnecta.com
         </a>
         .
       </p>
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Cambios en esta política</h2>
+      <p>
+        Podemos modificar esta política en cualquier momento. Las actualizaciones se
+        publicarán en esta página.
+      </p>
     </div>
+    <Footer />
   </div>
 );
 

--- a/src/pages/RefundPolicy.tsx
+++ b/src/pages/RefundPolicy.tsx
@@ -1,24 +1,42 @@
+import { Footer } from "@/components/landing/footer";
+
 const RefundPolicy = () => (
-  <div className="min-h-screen bg-gradient-to-b from-gray-900 to-gray-950 text-gray-100 py-20 px-4">
-    <div className="container mx-auto max-w-3xl space-y-6">
-      <h1 className="text-4xl font-bold mb-10 text-center">Política de Reembolsos</h1>
-      <p>
-        Queremos que estés satisfecho con tu compra en COINNECTA. Si el contenido no
-        cumple con tus expectativas, puedes solicitar un reembolso dentro de los 7
-        días posteriores a la compra.
+  <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-900 to-gray-950 text-gray-100">
+    <div className="flex-grow container mx-auto max-w-3xl px-4 py-20">
+      <div className="flex justify-center mb-10">
+        <img src={"images/logo.png"} alt="COINNECTA" className="w-40 lg:w-52" />
+      </div>
+      <h1 className="text-4xl font-bold text-center mb-8">Política de Reembolsos</h1>
+      <p className="mb-4">
+        En COINNECTA buscamos tu satisfacción. Si el contenido no cumple con tus
+        expectativas, puedes solicitar un reembolso dentro del plazo establecido.
       </p>
-      <p>
-        Para iniciar el proceso, contáctanos a través de
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Período de Reembolso</h2>
+      <p className="mb-4">
+        Tienes hasta 7 días desde la fecha de compra para solicitar la devolución
+        del producto digital.
+      </p>
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Condiciones</h2>
+      <ul className="list-disc list-inside mb-4 space-y-2">
+        <li>El reembolso se aplica únicamente al valor del producto adquirido.</li>
+        <li>No se devolverán comisiones o cargos de la plataforma de pago.</li>
+        <li>El acceso al contenido se revocará una vez aprobado el reembolso.</li>
+      </ul>
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Cómo solicitarlo</h2>
+      <p className="mb-4">
+        Escríbenos a
         <a href="mailto:hola@coinnecta.com" className="text-golden underline ml-1">
           hola@coinnecta.com
         </a>
-        indicando el motivo de tu solicitud y los detalles de tu compra.
+        indicando el motivo y los datos de tu compra.
       </p>
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Actualizaciones</h2>
       <p>
-        Las solicitudes recibidas después de este período no serán elegibles para
-        reembolso.
+        Podemos modificar esta política en cualquier momento y los cambios se
+        publicarán en este sitio.
       </p>
     </div>
+    <Footer />
   </div>
 );
 

--- a/src/pages/TermsOfUse.tsx
+++ b/src/pages/TermsOfUse.tsx
@@ -1,30 +1,50 @@
+import { Footer } from "@/components/landing/footer";
+
 const TermsOfUse = () => (
-  <div className="min-h-screen bg-gradient-to-b from-gray-900 to-gray-950 text-gray-100 py-20 px-4">
-    <div className="container mx-auto max-w-3xl space-y-6">
-      <h1 className="text-4xl font-bold mb-10 text-center">Términos de Uso</h1>
-      <p>
-        Bienvenido a COINNECTA. Al acceder y utilizar nuestro sitio web y servicios,
-        aceptas cumplir con los siguientes términos y condiciones. Si no estás de
-        acuerdo con alguna parte de estos términos, te recomendamos no utilizar
-        nuestra plataforma.
+  <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-900 to-gray-950 text-gray-100">
+    <div className="flex-grow container mx-auto max-w-3xl px-4 py-20">
+      <div className="flex justify-center mb-10">
+        <img src={"images/logo.png"} alt="COINNECTA" className="w-40 lg:w-52" />
+      </div>
+      <h1 className="text-4xl font-bold text-center mb-8">Términos de Uso</h1>
+      <p className="mb-4">
+        Bienvenido a COINNECTA. Al acceder y utilizar este sitio aceptas los
+        siguientes términos y condiciones. Si no estás de acuerdo con alguno de
+        ellos, te recomendamos no utilizar nuestros servicios.
       </p>
-      <p>
-        Todo el contenido disponible en este sitio es propiedad de COINNECTA y está
-        protegido por las leyes de derechos de autor. No se permite su reproducción
-        total o parcial sin autorización expresa.
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Uso del Sitio</h2>
+      <p className="mb-4">
+        Solo puedes utilizar COINNECTA para fines personales y lícitos. Está
+        prohibida la distribución no autorizada del contenido o cualquier acción
+        que pueda afectar el funcionamiento de la plataforma.
       </p>
-      <p>
-        Nos reservamos el derecho de modificar estos términos en cualquier momento.
-        Las modificaciones entrarán en vigor una vez publicadas en este sitio.
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Propiedad Intelectual</h2>
+      <p className="mb-4">
+        Los materiales disponibles, incluidos textos, imágenes y videos, son
+        propiedad de COINNECTA o de sus autores. Su reproducción total o parcial
+        requiere autorización previa por escrito.
       </p>
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Limitación de Responsabilidad</h2>
+      <p className="mb-4">
+        La información ofrecida tiene fines educativos y no garantiza resultados
+        específicos. COINNECTA no se responsabiliza por pérdidas derivadas del uso
+        del contenido.
+      </p>
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Modificaciones</h2>
+      <p className="mb-4">
+        Podemos actualizar estos términos en cualquier momento. Las
+        modificaciones entrarán en vigor una vez publicadas en este sitio.
+      </p>
+      <h2 className="text-2xl font-semibold mt-8 mb-4">Contacto</h2>
       <p>
-        Si tienes alguna pregunta, puedes contactarnos en
+        Si tienes preguntas sobre estos términos, escríbenos a
         <a href="mailto:hola@coinnecta.com" className="text-golden underline ml-1">
           hola@coinnecta.com
         </a>
         .
       </p>
     </div>
+    <Footer />
   </div>
 );
 


### PR DESCRIPTION
## Summary
- add hero-style logo and footer to terms, privacy, and refund pages
- rewrite policy content with improved sections and styling

## Testing
- `npm run lint` (fails: @typescript-eslint/no-empty-object-type)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac59818b9c832a95df56e5f50b5357